### PR TITLE
Wrap header logo with link to homepage

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -5,7 +5,9 @@ import ContributeButton from './ContributeButton.astro';
 
 <header class="flex">
   <div class="w-64 space-y-8 border-r border-gray-200 bg-white p-6">
-    <img src={Logo.src} />
+    <a href="/" class="inline-block w-fit">
+      <img src={Logo.src} alt="TechTerms logo" />
+    </a>
   </div>
   <nav class="flex flex-1 items-center justify-between border-b border-gray-200 p-6">
     <span class="text-lg">TechTerms.io</span>


### PR DESCRIPTION
Closes #51 

Thir PR wraps the header logo in a link that redirects to the homepage ("/").
Also added `w-fit` and `inline-block` classes to ensure that only the logo itself is clickable, not the entire parent block.