### PR TITLE
Fix Github Version redirect

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -15,7 +15,7 @@ import { version } from '../../version.json';
       <span class="text-lg">TechTerms.io</span>
 
       <a
-        href="https://github.com/techterms/techterms/releases/tag/v{version}"
+        href={`https://github.com/techterms/techterms/releases/tag/v${version}`}
         target="_blank"
         class="rounded-md bg-gray-700 px-2 py-1 font-mono text-xs font-bold text-white"
       >


### PR DESCRIPTION
Fixed the Github version redirect issue by including backticks to properly integrate the variable.

Issue Mentioned : https://github.com/techterms/techterms/issues/83