### PR TITLE
feat: create embeddable single term page

### DIFF
--- a/src/components/EmbeddedDefinitionCard.astro
+++ b/src/components/EmbeddedDefinitionCard.astro
@@ -1,0 +1,71 @@
+---
+import type { Definition } from '../models/Definition';
+import BlueskyIcon from '../assets/bluesky.svg';
+import TwitterIcon from '../assets/twitterx.svg';
+
+interface Props {
+  definition: Definition;
+}
+
+const { definition } = Astro.props;
+---
+
+<div data-type="definition-card" class="w-full p-4">
+  <div class="mb-4 flex items-center justify-between">
+    <p class="text-sm text-gray-600">
+      {
+        definition.categories.map(category => (
+          <span class="mr-2 rounded-md bg-green-500 px-2 py-1 text-sm text-white">{category}</span>
+        ))
+      }
+    </p>
+
+    <div>
+      <button
+        type="button"
+        data-type="share-on-bsky-button"
+        data-definition-id={definition.id}
+        data-definition-term={definition.term}
+        data-definition-explanation={definition.explanation}
+        class="rounded-md px-2 py-1 hover:cursor-pointer hover:bg-gray-100"
+      >
+        <img src={BlueskyIcon.src} alt="Share on Bluesky" class="h-4 w-4" />
+      </button>
+
+      <button
+        type="button"
+        data-type="share-on-x-button"
+        data-definition-id={definition.id}
+        data-definition-term={definition.term}
+        data-definition-explanation={definition.explanation}
+        class="rounded-md px-2 py-1 hover:cursor-pointer hover:bg-gray-100"
+      >
+        <img src={TwitterIcon.src} alt="Share on Twitter" class="h-4 w-4" />
+      </button>
+    </div>
+  </div>
+
+  <h2 data-type="definition-term" class="mb-2 text-lg font-bold">
+    <a href={`/t/${definition.id}`} class="text-black hover:text-blue-900">{definition.term}</a>
+  </h2>
+  <p data-type="definition-explanation" class="text-sm text-gray-600">{definition.explanation}</p>
+
+  <hr class="my-4 border-gray-200" />
+
+  {
+    definition.related && definition.related.length > 0 && (
+      <>
+        <p class="text-sm font-bold">Related:</p>
+        <ul class="list-inside list-disc">
+          {definition.related.map(related => (
+            <li>
+              <a href={related} class="text-sm text-blue-500 hover:text-blue-700">
+                {related}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </>
+    )
+  }
+</div>

--- a/src/components/EmbeddedDefinitionCard.astro
+++ b/src/components/EmbeddedDefinitionCard.astro
@@ -1,71 +1,35 @@
 ---
 import type { Definition } from '../models/Definition';
-import BlueskyIcon from '../assets/bluesky.svg';
-import TwitterIcon from '../assets/twitterx.svg';
 
 interface Props {
   definition: Definition;
 }
 
 const { definition } = Astro.props;
+const domain = Astro.site || 'https://techterms.io';
 ---
 
 <div data-type="definition-card" class="w-full p-4">
-  <div class="mb-4 flex items-center justify-between">
-    <p class="text-sm text-gray-600">
-      {
-        definition.categories.map(category => (
-          <span class="mr-2 rounded-md bg-green-500 px-2 py-1 text-sm text-white">{category}</span>
-        ))
-      }
-    </p>
-
-    <div>
-      <button
-        type="button"
-        data-type="share-on-bsky-button"
-        data-definition-id={definition.id}
-        data-definition-term={definition.term}
-        data-definition-explanation={definition.explanation}
-        class="rounded-md px-2 py-1 hover:cursor-pointer hover:bg-gray-100"
-      >
-        <img src={BlueskyIcon.src} alt="Share on Bluesky" class="h-4 w-4" />
-      </button>
-
-      <button
-        type="button"
-        data-type="share-on-x-button"
-        data-definition-id={definition.id}
-        data-definition-term={definition.term}
-        data-definition-explanation={definition.explanation}
-        class="rounded-md px-2 py-1 hover:cursor-pointer hover:bg-gray-100"
-      >
-        <img src={TwitterIcon.src} alt="Share on Twitter" class="h-4 w-4" />
-      </button>
-    </div>
-  </div>
-
-  <h2 data-type="definition-term" class="mb-2 text-lg font-bold">
-    <a href={`/t/${definition.id}`} class="text-black hover:text-blue-900">{definition.term}</a>
+  <h2 data-type="definition-term" class="mb-4 text-lg font-bold">
+    <a href={`${domain}/t/${definition.id}`} class="text-black hover:text-blue-900"
+      >{definition.term}</a
+    >
   </h2>
-  <p data-type="definition-explanation" class="text-sm text-gray-600">{definition.explanation}</p>
 
-  <hr class="my-4 border-gray-200" />
+  <p class="mb-4 text-sm text-gray-600">{definition.explanation}</p>
 
-  {
-    definition.related && definition.related.length > 0 && (
-      <>
-        <p class="text-sm font-bold">Related:</p>
-        <ul class="list-inside list-disc">
-          {definition.related.map(related => (
-            <li>
-              <a href={related} class="text-sm text-blue-500 hover:text-blue-700">
-                {related}
-              </a>
-            </li>
-          ))}
-        </ul>
-      </>
-    )
-  }
+  <p class="mb-4 text-sm text-gray-600">
+    <span class="font-bold">{definition.categories.length > 1 ? 'Categories:' : 'Category:'}</span>
+    {
+      definition.categories.map(category => (
+        <a href={`${domain}/c/${category}`} target="_blank" rel="noopener noreferrer">
+          <span class="mr-2 rounded-md bg-green-500 px-2 py-1 text-sm text-white">{category}</span>
+        </a>
+      ))
+    }
+  </p>
+
+  <p class="text-sm text-gray-600">
+    <a href={domain} class="text-sm text-gray-600">🔗 TechTerms.io</a>
+  </p>
 </div>

--- a/src/pages/embed/t/[id].astro
+++ b/src/pages/embed/t/[id].astro
@@ -1,0 +1,40 @@
+---
+import '../../../styles/global.css';
+import Layout from '../../../layouts/Layout.astro';
+import EmbeddedDefinitionCard from '../../../components/EmbeddedDefinitionCard.astro';
+
+import { definitions } from '../../../data/definitions';
+
+export function getStaticPaths() {
+  const definitionIds = definitions.map(definition => definition.id);
+  return definitionIds.map(id => ({ params: { id } }));
+}
+
+const { id } = Astro.params;
+const definition = definitions.find(definition => definition.id === id);
+if (!definition) {
+  throw new Error('Definition not found!');
+}
+
+// SEO properties for the term page
+const title = `${definition.term} - Simple Explanations of Common Tech Terms & Concepts | Tech Terms`;
+const description =
+  definition.explanation.length > 160
+    ? definition.explanation.substring(0, 157) + '...'
+    : definition.explanation;
+const canonical = new URL(`/t/${id}`, Astro.site || 'https://techterms.io').href;
+const tags = [definition.term, ...definition.categories, 'technology', 'definition'];
+---
+
+<Layout
+  title={title}
+  description={description}
+  canonical={canonical}
+  type="article"
+  section="Technology Definitions"
+  tags={tags}
+>
+  <EmbeddedDefinitionCard definition={definition} />
+</Layout>
+
+<script src="/src/scripts/share.ts"></script>


### PR DESCRIPTION
This PR creates a new single term page that can be used for embedding the definition.

Previously we had only `techterms.io/t/[term]` which displays the styled term.

With this PR we can access `techterms.io/embed/t/[term]` which is a simpler UI that can be embedded.

**Further improvements:**
- #106

**Closes:**
- #85 