### PR TITLE
fix(html): replaced deprecated apple-mobile-capable meta tag

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -92,7 +92,7 @@ const siteUrl = 'https://techterms.io';
     <!-- Additional SEO Meta Tags -->
     <meta name="theme-color" content="#3B82F6" />
     <meta name="msapplication-TileColor" content="#3B82F6" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content={siteName} />
 


### PR DESCRIPTION
- Standardized with mobile-web-app-capable meta tag per warning. 
- Addresses deprecation warning and ensures consistent fullscreen behavior.

Closes: #88