### PR TITLE
feat: add toast notification copied to clipboard

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -131,5 +131,12 @@ const siteUrl = 'https://techterms.io';
   <body class="min-h-screen">
     <slot />
     <Analytics />
+    <div
+      id="toast"
+      class="pointer-events-none fixed right-4 bottom-4 z-50 rounded bg-blue-600 px-4 py-2 text-white opacity-0 shadow-lg transition-opacity duration-300"
+    >
+      Copied to clipboard!
+    </div>
+    <script src="/src/scripts/clipboard.ts"></script>
   </body>
 </html>

--- a/src/scripts/clipboard.ts
+++ b/src/scripts/clipboard.ts
@@ -1,5 +1,14 @@
 export const BASE_URL = 'https://techterms.io';
 
+function showToast(message: string) {
+  const toast = document.getElementById('toast');
+  if (toast) {
+    toast.textContent = message;
+    toast.classList.add('show');
+    setTimeout(() => toast.classList.remove('show'), 2000);
+  }
+}
+
 function initCopyToClipboard() {
   const buttons = document.querySelectorAll('[data-type="copy-to-clipboard-button"]');
   if (!buttons || buttons.length === 0) {
@@ -18,7 +27,9 @@ function initCopyToClipboard() {
 
       const url = `${BASE_URL}/t/${definitionId}`;
       const text = `${definitionTerm} = ${definitionExplanation}\n\n${url}`;
-      navigator.clipboard.writeText(text);
+      navigator.clipboard.writeText(text).then(() => {
+        showToast('Copied to Clipboard!');
+      });
     });
   });
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,10 @@
 @import 'tailwindcss';
 
+#toast.show {
+  opacity: 1;
+  pointer-events: auto;
+}
+
 .gradient-text {
   background: linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%);
   -webkit-background-clip: text;


### PR DESCRIPTION
- Added toast function to clipboard.ts
- Added #toast.show to global.css
- Added `<div>` to layout.astro `<body>` using tailwind to populate the notification in the bottom right of the main screen

A toast notification was requested for copy-to-clipboard actions. Since I was unable to find a toast library compatible with Astro 5.x, I implememnted a custom solution using a simple `<div> `element, TailwindCSS, and a small JavaScript function to the clipboard function to show/hide the toast. This approach ensures the notification works across all pages without the need for extra dependecies or compatability issues. 

If a suitable Astro toast library is found or available in the future, the implementation can be uploaded to use it.

<img width="1000" height="2000" alt="techterm clipboard" src="https://github.com/user-attachments/assets/7fe0c02b-5c26-463a-890c-6fcda91907e2" />
