### PR TITLE
feat: add dynamic year in the footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,5 +1,9 @@
+---
+const year = new Date().getFullYear();
+---
+
 <footer class="mb-6 text-center text-sm">
-  <span class="color-gray-600">Copyright (c) 2025 Tech Terms Community</span> | <a
+  <span class="color-gray-600">Copyright (c) {year} Tech Terms Community</span> | <a
     href="https://github.com/techterms/techterms"
     target="_blank"
     rel="noopener noreferrer">Github</a

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "astro/tsconfigs/base",
   "compilerOptions": {
-    "strictNullChecks": true, // add if using `base` template
-    "allowJs": true // required, and included with all Astro templates
+    "strictNullChecks": true,
+    "allowJs": true
   }
 }


### PR DESCRIPTION
This PR changes the Copyright Year from Footer. Previously, the year is hardcoded. With this PR, it becomes dynamic.